### PR TITLE
Enable wrapping of JSX statements

### DIFF
--- a/lib/reactWrapper.js
+++ b/lib/reactWrapper.js
@@ -32,7 +32,18 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-function wrap(WrappedComponent) {
+/* wrap takes a Component or a JSX-statement and recursively replaces 
+   the prop 'cls' with the respective 'style' definitions.
+   Usually, wrapping a whole Class / Component will do the trick,
+   but for some render function (specifically ListView -> renderHeader) 
+   this will not work. Hence the JSX-output of such functions can also be 
+   wrapped */
+function wrap(componentOrElement) {
+    if (_react2.default.isValidElement(componentOrElement)) {
+        var element = componentOrElement;
+        return recursiveStyle(element);
+    }
+    var WrappedComponent = componentOrElement;
     var newClass = function (_WrappedComponent) {
         _inherits(newClass, _WrappedComponent);
 
@@ -45,86 +56,7 @@ function wrap(WrappedComponent) {
         _createClass(newClass, [{
             key: "render",
             value: function render() {
-                return this._recursiveStyle(_get(newClass.prototype.__proto__ || Object.getPrototypeOf(newClass.prototype), "render", this).call(this));
-            }
-        }, {
-            key: "_recursiveStyle",
-            value: function _recursiveStyle(elementsTree) {
-                var props = elementsTree.props;
-
-                var newProps = void 0;
-                var translated = false;
-
-                /* Parse cls string */
-                if (_lodash2.default.isString(props.cls)) {
-                    newProps = {};
-                    translated = true;
-                    if (_lodash2.default.isArray(props.style)) {
-                        newProps.style = props.style.slice();
-                    } else if (_lodash2.default.isObject(props.style)) {
-                        newProps.style = [props.style];
-                    } else {
-                        newProps.style = [];
-                    }
-
-                    var splitted = props.cls.replace(/-/g, "_").split(" ");
-                    for (var i = 0; i < splitted.length; i++) {
-                        var cls = splitted[i];
-                        if (cls.length > 0) {
-                            var style = _index.styles[cls];
-                            if (style) {
-
-                                /* Style found */
-                                newProps.style.push(style);
-                            } else if (cls.startsWith("bg_")) {
-                                newProps.style.push({
-                                    backgroundColor: cls.slice(3)
-                                });
-                            } else if (cls.startsWith("b__")) {
-                                newProps.style.push({
-                                    borderColor: cls.slice(3)
-                                });
-                            } else if (_cssColorNames2.default[cls] || /^(rgb|#|hsl)/.test(cls)) {
-                                newProps.style.push({
-                                    color: cls
-                                });
-                            } else {
-                                throw new Error("style '" + cls + "' not found");
-                            }
-                        }
-                    }
-                }
-
-                var newChildren = props.children;
-                if (_lodash2.default.isArray(newChildren)) {
-
-                    /* Convert child array */
-                    newChildren = _react2.default.Children.toArray(newChildren);
-                    for (var _i = 0; _i < newChildren.length; _i++) {
-                        var c = newChildren[_i];
-                        if (_react2.default.isValidElement(c)) {
-                            var converted = this._recursiveStyle(c);
-                            if (converted !== c) {
-                                translated = true;
-                                newChildren[_i] = converted;
-                            }
-                        }
-                    }
-                } else if (_react2.default.isValidElement(newChildren)) {
-
-                    /* Convert single child */
-                    var _converted = this._recursiveStyle(newChildren);
-                    if (_converted !== newChildren) {
-                        translated = true;
-                        newChildren = _converted;
-                    }
-                }
-
-                if (translated) {
-                    return _react2.default.cloneElement(elementsTree, newProps, newChildren);
-                }
-
-                return elementsTree;
+                return recursiveStyle(_get(newClass.prototype.__proto__ || Object.getPrototypeOf(newClass.prototype), "render", this).call(this));
             }
         }]);
 
@@ -135,4 +67,82 @@ function wrap(WrappedComponent) {
     newClass.displayName = WrappedComponent.displayName || WrappedComponent.name;
 
     return newClass;
+}
+
+function recursiveStyle(elementsTree) {
+    var props = elementsTree.props;
+
+    var newProps = void 0;
+    var translated = false;
+
+    /* Parse cls string */
+    if (_lodash2.default.isString(props.cls)) {
+        newProps = {};
+        translated = true;
+        if (_lodash2.default.isArray(props.style)) {
+            newProps.style = props.style.slice();
+        } else if (_lodash2.default.isObject(props.style)) {
+            newProps.style = [props.style];
+        } else {
+            newProps.style = [];
+        }
+
+        var splitted = props.cls.replace(/-/g, "_").split(" ");
+        for (var i = 0; i < splitted.length; i++) {
+            var cls = splitted[i];
+            if (cls.length > 0) {
+                var style = _index.styles[cls];
+                if (style) {
+
+                    /* Style found */
+                    newProps.style.push(style);
+                } else if (cls.startsWith("bg_")) {
+                    newProps.style.push({
+                        backgroundColor: cls.slice(3)
+                    });
+                } else if (cls.startsWith("b__")) {
+                    newProps.style.push({
+                        borderColor: cls.slice(3)
+                    });
+                } else if (_cssColorNames2.default[cls] || /^(rgb|#|hsl)/.test(cls)) {
+                    newProps.style.push({
+                        color: cls
+                    });
+                } else {
+                    throw new Error("style '" + cls + "' not found");
+                }
+            }
+        }
+    }
+
+    var newChildren = props.children;
+    if (_lodash2.default.isArray(newChildren)) {
+
+        /* Convert child array */
+        newChildren = _react2.default.Children.toArray(newChildren);
+        for (var _i = 0; _i < newChildren.length; _i++) {
+            var c = newChildren[_i];
+            if (_react2.default.isValidElement(c)) {
+                var converted = recursiveStyle(c);
+                if (converted !== c) {
+                    translated = true;
+                    newChildren[_i] = converted;
+                }
+            }
+        }
+    } else if (_react2.default.isValidElement(newChildren)) {
+
+        /* Convert single child */
+        var _converted = recursiveStyle(newChildren);
+        if (_converted !== newChildren) {
+            translated = true;
+            newChildren = _converted;
+        }
+    }
+
+    if (translated) {
+        return _react2.default.cloneElement(elementsTree, newProps, newChildren);
+    }
+
+    return elementsTree;
 }

--- a/lib/reactWrapper.js
+++ b/lib/reactWrapper.js
@@ -8,6 +8,8 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
 
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
 exports.wrap = wrap;
 
 var _react = require("react");
@@ -38,12 +40,20 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
    but for some render function (specifically ListView -> renderHeader) 
    this will not work. Hence the JSX-output of such functions can also be 
    wrapped */
-function wrap(componentOrElement) {
-    if (_react2.default.isValidElement(componentOrElement)) {
-        var element = componentOrElement;
-        return recursiveStyle(element);
+function wrap(componentOrFunction) {
+    if (_typeof(componentOrFunction.prototype.isReactComponent) !== 'object') {
+        var _ret = function () {
+            var func = componentOrFunction;
+            return {
+                v: function v() {
+                    return recursiveStyle(func.apply(this, arguments));
+                }
+            };
+        }();
+
+        if ((typeof _ret === "undefined" ? "undefined" : _typeof(_ret)) === "object") return _ret.v;
     }
-    var WrappedComponent = componentOrElement;
+    var WrappedComponent = componentOrFunction;
     var newClass = function (_WrappedComponent) {
         _inherits(newClass, _WrappedComponent);
 

--- a/src/reactWrapper.js
+++ b/src/reactWrapper.js
@@ -3,95 +3,21 @@ import _ from "lodash";
 import { styles } from "./index";
 import cssColors from "css-color-names"
 
-export function wrap(WrappedComponent) {
+/* wrap takes a Component or a JSX-statement and recursively replaces 
+   the prop 'cls' with the respective 'style' definitions.
+   Usually, wrapping a whole Class / Component will do the trick,
+   but for some render function (specifically ListView -> renderHeader) 
+   this will not work. Hence the JSX-output of such functions can also be 
+   wrapped */
+export function wrap(componentOrElement) {
+    if (React.isValidElement(componentOrElement)) {
+        const element = componentOrElement;
+        return recursiveStyle(element);
+    }
+    const WrappedComponent = componentOrElement;
     const newClass = class extends WrappedComponent {
         render() {
-            return this._recursiveStyle(super.render());
-        }
-
-        _recursiveStyle(elementsTree) {
-            const { props } = elementsTree;
-            let newProps;
-            let translated = false;
-
-            /* Parse cls string */
-            if (_.isString(props.cls)) {
-                newProps = {}
-                translated = true
-                if (_.isArray(props.style)) {
-                    newProps.style = props.style.slice()
-
-                } else if (_.isObject(props.style)) {
-                    newProps.style = [props.style]
-
-                } else {
-                    newProps.style = []
-                }
-
-                const splitted = props.cls.replace(/-/g, "_").split(" ")
-                for (let i = 0; i < splitted.length; i++) {
-                    const cls = splitted[i];
-                    if (cls.length > 0) {
-                        const style = styles[cls];
-                        if (style) {
-
-                            /* Style found */
-                            newProps.style.push(style);
-
-                        } else if (cls.startsWith("bg_")) {
-                            newProps.style.push({
-                                backgroundColor: cls.slice(3)
-                            })
-
-                        } else if (cls.startsWith("b__")) {
-                            newProps.style.push({
-                                borderColor: cls.slice(3)
-                            })
-
-                        } else if (cssColors[cls] || (/^(rgb|#|hsl)/).test(cls)) {
-                            newProps.style.push({
-                                color: cls
-                            })
-
-                        } else {
-                            throw new Error(`style '${cls}' not found`);
-                        }
-
-                    }
-                }
-            }
-
-            let newChildren = props.children;
-            if (_.isArray(newChildren)) {
-
-                /* Convert child array */
-                newChildren = React.Children.toArray(newChildren);
-                for (let i = 0; i < newChildren.length; i++) {
-                    const c = newChildren[i];
-                    if (React.isValidElement(c)) {
-                        const converted = this._recursiveStyle(c);
-                        if (converted !== c) {
-                            translated = true;
-                            newChildren[i] = converted;
-                        }
-                    }
-                }
-
-            } else if (React.isValidElement(newChildren)) {
-
-                /* Convert single child */
-                const converted = this._recursiveStyle(newChildren);
-                if (converted !== newChildren) {
-                    translated = true;
-                    newChildren = converted;
-                }
-            }
-
-            if (translated) {
-                return React.cloneElement(elementsTree, newProps, newChildren)
-            }
-
-            return elementsTree;
+            return recursiveStyle(super.render());
         }
     }
 
@@ -101,3 +27,87 @@ export function wrap(WrappedComponent) {
     return newClass;
 }
 
+function recursiveStyle(elementsTree) {
+    const { props } = elementsTree;
+    let newProps;
+    let translated = false;
+
+    /* Parse cls string */
+    if (_.isString(props.cls)) {
+        newProps = {}
+        translated = true
+        if (_.isArray(props.style)) {
+            newProps.style = props.style.slice()
+
+        } else if (_.isObject(props.style)) {
+            newProps.style = [props.style]
+
+        } else {
+            newProps.style = []
+        }
+
+        const splitted = props.cls.replace(/-/g, "_").split(" ")
+        for (let i = 0; i < splitted.length; i++) {
+            const cls = splitted[i];
+            if (cls.length > 0) {
+                const style = styles[cls];
+                if (style) {
+
+                    /* Style found */
+                    newProps.style.push(style);
+
+                } else if (cls.startsWith("bg_")) {
+                    newProps.style.push({
+                        backgroundColor: cls.slice(3)
+                    })
+
+                } else if (cls.startsWith("b__")) {
+                    newProps.style.push({
+                        borderColor: cls.slice(3)
+                    })
+
+                } else if (cssColors[cls] || (/^(rgb|#|hsl)/).test(cls)) {
+                    newProps.style.push({
+                        color: cls
+                    })
+
+                } else {
+                    throw new Error(`style '${cls}' not found`);
+                }
+
+            }
+        }
+    }
+
+    let newChildren = props.children;
+    if (_.isArray(newChildren)) {
+
+        /* Convert child array */
+        newChildren = React.Children.toArray(newChildren);
+        for (let i = 0; i < newChildren.length; i++) {
+            const c = newChildren[i];
+            if (React.isValidElement(c)) {
+                const converted = recursiveStyle(c);
+                if (converted !== c) {
+                    translated = true;
+                    newChildren[i] = converted;
+                }
+            }
+        }
+
+    } else if (React.isValidElement(newChildren)) {
+
+        /* Convert single child */
+        const converted = recursiveStyle(newChildren);
+        if (converted !== newChildren) {
+            translated = true;
+            newChildren = converted;
+        }
+    }
+
+    if (translated) {
+        return React.cloneElement(elementsTree, newProps, newChildren)
+    }
+
+    return elementsTree;
+}

--- a/src/reactWrapper.js
+++ b/src/reactWrapper.js
@@ -13,8 +13,8 @@ export function wrap(componentOrFunction) {
     if (typeof componentOrFunction.prototype.isReactComponent !== 'object') {
         const func = componentOrFunction;
 
-        return function () {
-            return recursiveStyle(func.apply(this, arguments))
+        return function wrappedRender(...args) {
+            return recursiveStyle(func.apply(this, args))
         };
     }
     const WrappedComponent = componentOrFunction;

--- a/src/reactWrapper.js
+++ b/src/reactWrapper.js
@@ -1,20 +1,23 @@
-import React from "react";
-import _ from "lodash";
-import { styles } from "./index";
-import cssColors from "css-color-names"
+import React from 'react';
+import _ from 'lodash';
+import { styles } from './index';
+import cssColors from 'css-color-names'
 
-/* wrap takes a Component or a JSX-statement and recursively replaces 
+/* wrap takes a Component or a render function and recursively replaces
    the prop 'cls' with the respective 'style' definitions.
    Usually, wrapping a whole Class / Component will do the trick,
-   but for some render function (specifically ListView -> renderHeader) 
-   this will not work. Hence the JSX-output of such functions can also be 
-   wrapped */
-export function wrap(componentOrElement) {
-    if (React.isValidElement(componentOrElement)) {
-        const element = componentOrElement;
-        return recursiveStyle(element);
+   but for some render functions (e.g. ListView -> renderHeader)
+   this will not work. Hence the such functions need to be wrapped
+   individually */
+export function wrap(componentOrFunction) {
+    if (typeof componentOrFunction.prototype.isReactComponent !== 'object') {
+        const func = componentOrFunction;
+
+        return function () {
+            return recursiveStyle(func.apply(this, arguments))
+        };
     }
-    const WrappedComponent = componentOrElement;
+    const WrappedComponent = componentOrFunction;
     const newClass = class extends WrappedComponent {
         render() {
             return recursiveStyle(super.render());
@@ -46,7 +49,7 @@ function recursiveStyle(elementsTree) {
             newProps.style = []
         }
 
-        const splitted = props.cls.replace(/-/g, "_").split(" ")
+        const splitted = props.cls.replace(/-/g, '_').split(' ')
         for (let i = 0; i < splitted.length; i++) {
             const cls = splitted[i];
             if (cls.length > 0) {
@@ -56,12 +59,12 @@ function recursiveStyle(elementsTree) {
                     /* Style found */
                     newProps.style.push(style);
 
-                } else if (cls.startsWith("bg_")) {
+                } else if (cls.startsWith('bg_')) {
                     newProps.style.push({
                         backgroundColor: cls.slice(3)
                     })
 
-                } else if (cls.startsWith("b__")) {
+                } else if (cls.startsWith('b__')) {
                     newProps.style.push({
                         borderColor: cls.slice(3)
                     })

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -195,8 +195,21 @@ test("wrapping", t => {
 });
 
 test("wrapping JSX", t => {
-    const orig = (<div cls="b">Some Text</div>);
-    const expexted = (<div cls="b" style={[{ fontWeight: 'bold' }]}>Some Text</div>);
+    const orig = (
+        <div 
+            cls="b"
+        >
+            Some Text
+        </div>
+    );
+    const expexted = (
+        <div 
+            cls="b"
+            style={[{ fontWeight: 'bold' }]}
+        >
+            Some Text
+        </div>
+    );
 
     const wrapped = wrap(orig);
     t.deepEqual(wrapped, expexted, "wrapped as expected");

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -193,3 +193,12 @@ test("wrapping", t => {
 
     t.end();
 });
+
+test("wrapping JSX", t => {
+    const orig = (<div cls="b">Some Text</div>);
+    const expexted = (<div cls="b" style={[{ fontWeight: 'bold' }]}>Some Text</div>);
+
+    const wrapped = wrap(orig);
+    t.deepEqual(wrapped, expexted, "wrapped as expected");
+    t.end();
+});

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -194,7 +194,7 @@ test('wrapping', t => {
     t.end();
 });
 
-test('wrapp createClass', t => {
+test('wrap createClass', t => {
     // eslint-disable-next-line react/prefer-es6-class
     const Orig = React.createClass({
         render() {

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -1,8 +1,8 @@
-import { test } from "tape";
-import { build, wrap, styles, sizes } from "../src/";
-import _ from "lodash";
-import React from "react";
-import Benchmark from "benchmark";
+import { test } from 'tape';
+import { build, wrap, styles, sizes } from '../src/';
+import _ from 'lodash';
+import React from 'react';
+import Benchmark from 'benchmark';
 
 function buildRNT(options) {
     for (const prop in styles) {
@@ -14,26 +14,26 @@ function buildRNT(options) {
     build(options, fakeStyleSheet);
 }
 
-test("styles", t => {
+test('styles', t => {
 
     buildRNT({})
 
     /* Sum of styles */
-    t.ok(_.isObject(styles), "styles is an object");
-    t.ok(_.has(styles, "w1"), "example: has w1");
-    t.ok(_.has(styles, "w5"), "example: has w5");
-    t.ok(_.has(styles, "pb7"), "example: has pb7");
-    t.ok(_.has(styles, "f1"), "example: has f1");
+    t.ok(_.isObject(styles), 'styles is an object');
+    t.ok(_.has(styles, 'w1'), 'example: has w1');
+    t.ok(_.has(styles, 'w5'), 'example: has w5');
+    t.ok(_.has(styles, 'pb7'), 'example: has pb7');
+    t.ok(_.has(styles, 'f1'), 'example: has f1');
 
-    t.ok(_.has(styles, "absolute_fill"), "example: has absolute-fill");
-    t.deepEqual(styles.pa3, { padding: 16 }, "pa3 is 16")
+    t.ok(_.has(styles, 'absolute_fill'), 'example: has absolute-fill');
+    t.deepEqual(styles.pa3, { padding: 16 }, 'pa3 is 16')
 
     /* Borders */
-    t.deepEqual(styles.br3, { borderRadius: 8 }, "br3 is 8")
-    t.deepEqual(styles.bl, { borderLeftWidth: 1 }, "bl works")
-    t.deepEqual(styles.br__top, { borderBottomLeftRadius: 0, borderBottomRightRadius: 0 }, "br--top works")
+    t.deepEqual(styles.br3, { borderRadius: 8 }, 'br3 is 8')
+    t.deepEqual(styles.bl, { borderLeftWidth: 1 }, 'bl works')
+    t.deepEqual(styles.br__top, { borderBottomLeftRadius: 0, borderBottomRightRadius: 0 }, 'br--top works')
 
-    t.deepEqual(styles.o_025, { opacity: 0.025 }, "o-025 is opacity 0.025")
+    t.deepEqual(styles.o_025, { opacity: 0.025 }, 'o-025 is opacity 0.025')
 
     t.deepEqual(styles.min_w3, { minWidth: 64 })
     t.deepEqual(styles.max_w3, { maxWidth: 64 })
@@ -41,81 +41,81 @@ test("styles", t => {
     t.deepEqual(styles.max_h4, { maxHeight: 128 })
 
     /* Underscore version are generated */
-    t.ok(_.has(styles, "flx_i"), "underscore version is generated in addition to hyphenated names")
+    t.ok(_.has(styles, 'flx_i'), 'underscore version is generated in addition to hyphenated names')
 
     t.end();
 });
 
-test("sizes", t => {
+test('sizes', t => {
     buildRNT({})
-    t.equal(sizes.pa3, 16, "pa3 is 16");
-    t.equal(sizes.max_w2, 32, "max_w2 is 32");
+    t.equal(sizes.pa3, 16, 'pa3 is 16');
+    t.equal(sizes.max_w2, 32, 'max_w2 is 32');
     t.end();
 })
 
-test("fonts", t => {
+test('fonts', t => {
     buildRNT({
         fonts: {
-            iowan: "Iowan Old Style"
+            iowan: 'Iowan Old Style'
         }
     })
-    t.deepEqual(styles.ff_iowan, { fontFamily: "Iowan Old Style" })
+    t.deepEqual(styles.ff_iowan, { fontFamily: 'Iowan Old Style' })
     t.end();
 })
 
-test("colors", t => {
+test('colors', t => {
     buildRNT({
         colors: {
             palette: {
-                green: "#00FF00",
-                light_green: "#00FF00"
+                green: '#00FF00',
+                light_green: '#00FF00'
             }
         }
     });
 
-    t.deepEqual(styles.green, { color: "#00FF00" })
-    t.deepEqual(styles.b__green, { borderColor: "#00FF00" })
-    t.deepEqual(styles.bg_green, { backgroundColor: "#00FF00" })
-    t.deepEqual(styles.bg_light_green, { backgroundColor: "#00FF00" })
+    t.deepEqual(styles.green, { color: '#00FF00' })
+    t.deepEqual(styles.b__green, { borderColor: '#00FF00' })
+    t.deepEqual(styles.bg_green, { backgroundColor: '#00FF00' })
+    t.deepEqual(styles.bg_light_green, { backgroundColor: '#00FF00' })
 
-    t.ok(_.has(styles, "b__green"), "multiple underscores work")
+    t.ok(_.has(styles, 'b__green'), 'multiple underscores work')
 
     t.end();
 });
 
-test("wrapping", t => {
+test('wrapping', t => {
 
     function createComponent(clsStr, style) {
         const comp = class extends React.Component {
             render() {
                 return (
                     <div
-                        key="1"
-                        other="2"
-                        cls={clsStr}
-                        style={style}
+                      key="1"
+                      other="2"
+                      cls={clsStr}
+                      style={style}
                     >
                         <div
-                            key="child1"
-                            cls="w2"
+                          key="child1"
+                          cls="w2"
                         >
                             <div cls="w4" />
                         </div>
                         <div
-                            key="child2"
-                            cls="w1"
+                          key="child2"
+                          cls="w1"
                         >
                             Test
                         </div>
                         <div
-                            key="child3"
-                            cls="w2"
+                          key="child3"
+                          cls="w2"
                         >
                             <div />
                         </div>
                         <div
-                            key="child4"
-                            cls="bg-#abcdef b--rgba(200,144,233,1.0) burlywood"
+                          key="child4"
+                          cls="bg-#abcdef b--rgba(200,144,233,1.0) burlywood"
                         >
                             <div />
                         </div>
@@ -124,7 +124,7 @@ test("wrapping", t => {
             }
         }
 
-        comp.displayName = "Orig"
+        comp.displayName = 'Orig'
 
         return comp
     }
@@ -135,58 +135,58 @@ test("wrapping", t => {
         return new Comp().render()
     }
 
-    const Orig = createComponent("w5")
+    const Orig = createComponent('w5')
     const Wrapped = wrap(Orig);
-    t.equal(Wrapped.displayName, Orig.displayName, "displayName is preserved");
+    t.equal(Wrapped.displayName, Orig.displayName, 'displayName is preserved');
 
-    let instance = renderComponent("w5")
-    t.deepEqual(instance.key, "1", "key is preserved");
-    t.deepEqual(instance.props.other, "2", "other properties are preserved");
+    let instance = renderComponent('w5')
+    t.deepEqual(instance.key, '1', 'key is preserved');
+    t.deepEqual(instance.props.other, '2', 'other properties are preserved');
 
     /* Children */
-    t.deepEqual(instance.props.children[0].props.cls, "w2", "child is preserved");
-    t.deepEqual(instance.props.children[0].props.style, [{ width: 32 }], "child cls is converted");
-    t.deepEqual(instance.props.children.length, 4, "children are converted");
-    t.deepEqual(instance.props.children[0].props.children.props.style, [{ width: 128 }], "nested single children are converted");
-    t.deepEqual(instance.props.children[1].props.children, "Test", "Non-ReactElement children are preserved");
-    t.ok(React.isValidElement(instance.props.children[2].props.children), "unaltered single children are preserved");
+    t.deepEqual(instance.props.children[0].props.cls, 'w2', 'child is preserved');
+    t.deepEqual(instance.props.children[0].props.style, [{ width: 32 }], 'child cls is converted');
+    t.deepEqual(instance.props.children.length, 4, 'children are converted');
+    t.deepEqual(instance.props.children[0].props.children.props.style, [{ width: 128 }], 'nested single children are converted');
+    t.deepEqual(instance.props.children[1].props.children, 'Test', 'Non-ReactElement children are preserved');
+    t.ok(React.isValidElement(instance.props.children[2].props.children), 'unaltered single children are preserved');
 
     t.deepEqual(
         instance.props.children[3].props.style,
         [
-            { backgroundColor: "#abcdef" },
-            { borderColor: "rgba(200,144,233,1.0)" },
-            { color: "burlywood" }
+            { backgroundColor: '#abcdef' },
+            { borderColor: 'rgba(200,144,233,1.0)' },
+            { color: 'burlywood' }
         ],
-        "ad-hoc colors are supported");
+        'ad-hoc colors are supported');
 
-    t.deepEqual(instance.props.style, [{ width: 256 }], "style array is created");
+    t.deepEqual(instance.props.style, [{ width: 256 }], 'style array is created');
 
-    instance = renderComponent("w5", { width: 5 })
-    t.deepEqual(instance.props.style, [{ width: 5 }, { width: 256 }], "existing style object is converted to array and appended");
+    instance = renderComponent('w5', { width: 5 })
+    t.deepEqual(instance.props.style, [{ width: 5 }, { width: 256 }], 'existing style object is converted to array and appended');
 
-    instance = renderComponent("w5", [{ width: 5 }])
-    t.deepEqual(instance.props.style, [{ width: 5 }, { width: 256 }], "existing style array is appended");
+    instance = renderComponent('w5', [{ width: 5 }])
+    t.deepEqual(instance.props.style, [{ width: 5 }, { width: 256 }], 'existing style array is appended');
 
-    instance = renderComponent("")
-    t.deepEqual(instance.props.style, [], "if style is undefined, an array will be created");
+    instance = renderComponent('')
+    t.deepEqual(instance.props.style, [], 'if style is undefined, an array will be created');
 
-    instance = renderComponent("flx-i")
-    t.deepEqual(instance.props.style, [{ flex: 1 }], "hyphens work");
+    instance = renderComponent('flx-i')
+    t.deepEqual(instance.props.style, [{ flex: 1 }], 'hyphens work');
 
     /* Throw when using invalid properties */
-    t.throws(() => renderComponent("w8"), /style 'w8' not found/)
+    t.throws(() => renderComponent('w8'), /style 'w8' not found/)
 
     /* Don't throw when setting css-color-names */
-    instance = renderComponent("azure")
-    t.deepEqual(instance.props.style, [{ color: "azure" }]);
+    instance = renderComponent('azure')
+    t.deepEqual(instance.props.style, [{ color: 'azure' }]);
 
 
     /* Benchmarking */
-    const inst = new (wrap(createComponent("w2", [])))();
+    const inst = new (wrap(createComponent('w2', [])))();
     new Benchmark.Suite()
-        .add("wrap", () => inst.render())
-        .on("cycle", event => {
+        .add('wrap', () => inst.render())
+        .on('cycle', event => {
             t.comment(`performance: ${event.target}`);
         })
         // .run()
@@ -194,24 +194,70 @@ test("wrapping", t => {
     t.end();
 });
 
-test("wrapping JSX", t => {
-    const orig = (
-        <div 
-            cls="b"
-        >
+test('wrapp createClass', t => {
+    // eslint-disable-next-line react/prefer-es6-class
+    const Orig = React.createClass({
+        render() {
+            return (
+                <div cls="b">hello</div>
+            );
+        }
+    });
+
+    // eslint-disable-next-line react/prefer-es6-class
+    const Expected = React.createClass({
+        render() {
+            return (
+                <div
+                  cls="b"
+                  style={[{ fontWeight: 'bold' }]}
+                >hello</div>
+            );
+        }
+    });
+    const WrappedComp = wrap(Orig);
+    const comp = new WrappedComp();
+    const expect = new Expected();
+
+    t.deepEqual(comp.render(), expect.render())
+    t.end();
+});
+
+test('wrapping render functions', t => {
+    let orig = () => (
+        <div cls="b">
             Some Text
         </div>
     );
-    const expexted = (
-        <div 
-            cls="b"
-            style={[{ fontWeight: 'bold' }]}
+    let expexted = () => (
+        <div
+          cls="b"
+          style={[{ fontWeight: 'bold' }]}
         >
             Some Text
         </div>
     );
 
-    const wrapped = wrap(orig);
-    t.deepEqual(wrapped, expexted, "wrapped as expected");
+    let wrapped = wrap(orig);
+    t.deepEqual(wrapped(), expexted(), 'render function wrapped as expected');
+
+    // eslint-disable-next-line react/display-name
+    orig = (arg1, arg2) => (
+        <div cls="b">
+            {arg1} {arg2}
+        </div>
+    );
+    // eslint-disable-next-line react/display-name
+    expexted = (arg1, arg2) => (
+        <div
+          cls="b"
+          style={[{ fontWeight: 'bold' }]}
+        >
+            {arg1} {arg2}
+        </div>
+    );
+
+    wrapped = wrap(orig);
+    t.deepEqual(wrapped(1, 2), expexted(1, 2), 'render function with arguments wrapped as expected');
     t.end();
 });


### PR DESCRIPTION
When using class-wrapping, some components, namely ListView or Navigator, will not properly expand the styles for its renderHeader / renderFooter / renderSeparator properties. With this PR, such methods can be wrapped:

```javascript
function renderHeader() {
    return NativeTachyons.wrap(
        <Text cls="b">Some Text</Text>
    )
}
```
