### PR TITLE
Add flexGrow

### DIFF
--- a/src/styles/flexbox.js
+++ b/src/styles/flexbox.js
@@ -5,7 +5,7 @@ export default {
     "flx-i": {
         flex: 1
     },
-    "flex-grow": {
+    "flx-grow": {
         flexGrow: 1
     },
     "flx-row": {

--- a/src/styles/flexbox.js
+++ b/src/styles/flexbox.js
@@ -5,6 +5,9 @@ export default {
     "flx-i": {
         flex: 1
     },
+    "flex-grow": {
+        flexGrow: 1
+    },
     "flx-row": {
         flexDirection: "row"
     },


### PR DESCRIPTION
Since newer react versions changed how flexBox behaves we have to use flexGrow instead of flex most of the time.