### PR TITLE
Lock `debug` dependency to 2.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "color": "^1.0.3",
     "css-color-names": "0.0.4",
-    "debug": "^2.6.4",
+    "debug": "2.6.4",
     "lodash": "^4.17.4"
   },
   "files": [


### PR DESCRIPTION
`debug` 2.6.5 reintroduces a breaking change accessing `browser`