### PR TITLE
Add new options to `NativeTachyons.build` function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ const NativeTachyons = {
     /* Placeholder */
     sizes: {},
 
+    options: {},
+
     build: function build(options = {}, StyleSheet) {
 
         _.defaultsDeep(options, {
@@ -33,7 +35,8 @@ const NativeTachyons = {
                 }
             },
             fonts: {
-            }
+            },
+            clsPropName: 'cls'
         })
 
         /* Assign all the styles */
@@ -101,6 +104,7 @@ const NativeTachyons = {
 
         _.assign(NativeTachyons.sizes, hyphensToUnderscores(sizes));
         _.assign(NativeTachyons.styles, StyleSheet.create(hyphensToUnderscores(styleSheet)));
+        _.assign(NativeTachyons.options, options);
     }
 }
 
@@ -117,4 +121,4 @@ function hyphensToUnderscores(sourceObj) {
 
 
 export default NativeTachyons;
-export const { sizes, styles, wrap, build } = NativeTachyons;
+export const { sizes, styles, wrap, build, options } = NativeTachyons;

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,8 @@ const NativeTachyons = {
             },
             fonts: {
             },
-            clsPropName: 'cls'
+            clsPropName: 'cls',
+            customStyles: {}
         })
 
         /* Assign all the styles */
@@ -101,6 +102,8 @@ const NativeTachyons = {
         _.forOwn(options.fonts, (val, key) => {
             styleSheet[`ff-${key}`] = { fontFamily: val }
         });
+
+        _.assign(styleSheet, options.customStyles);
 
         _.assign(NativeTachyons.sizes, hyphensToUnderscores(sizes));
         _.assign(NativeTachyons.styles, StyleSheet.create(hyphensToUnderscores(styleSheet)));

--- a/src/reactWrapper.js
+++ b/src/reactWrapper.js
@@ -1,10 +1,10 @@
 import React from "react";
 import _ from "lodash";
-import { styles } from "./index";
+import { styles, options } from "./index";
 import cssColors from "css-color-names"
 
 /* Wrap takes a Component or a render function and recursively replaces
-   the prop 'cls' with the respective 'style' definitions.
+   the prop 'cls' (or custom overriden prop name) with the respective 'style' definitions.
    Usually, wrapping a whole Class / Component will do the trick,
    but for some render functions (e.g. ListView -> renderHeader)
    this will not work. Hence the such functions need to be wrapped
@@ -32,11 +32,12 @@ export function wrap(componentOrFunction) {
 
 function recursiveStyle(elementsTree) {
     const { props } = elementsTree;
+    const { clsPropName } = options;
     let newProps;
     let translated = false;
 
     /* Parse cls string */
-    if (_.isString(props.cls)) {
+    if (_.isString(props[clsPropName])) {
         newProps = {}
         translated = true
         if (_.isArray(props.style)) {
@@ -49,7 +50,7 @@ function recursiveStyle(elementsTree) {
             newProps.style = []
         }
 
-        const splitted = props.cls.replace(/-/g, "_").split(" ")
+        const splitted = props[clsPropName].replace(/-/g, "_").split(" ")
         for (let i = 0; i < splitted.length; i++) {
             const cls = splitted[i];
             if (cls.length > 0) {


### PR DESCRIPTION
Add 2 new options:
```js
{
  clsPropName: 'cls',
  customStyles: {}
}
```

Allow an option to customize `cls` prop name. This is especially useful when using `react-pug` along with `clsPropName` set to 'className'.

Default value is `'cls'`.

I think it will also be pretty useful for users to be able define custom styles.