### PR TITLE
render function support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const hyphensToUnderscores = function(sourceObj) {
 
     /* Create hypened versions */
     _.forOwn(sourceObj, (val, key) => {
-        translated[key.replace(/-/g, "_")] = val;
+        translated[key.replace(/-/gu, "_")] = val;
     })
 
     return translated;

--- a/src/reactWrapper.js
+++ b/src/reactWrapper.js
@@ -83,7 +83,7 @@ function setStyles(props, clsPropName) {
                     tintColor: cls.slice(3)
                 })
 
-            } else if (cssColors[cls] || (/^(rgb|#|hsl)/).test(cls)) {
+            } else if (cssColors[cls] || (/^(rgb|#|hsl)/u).test(cls)) {
                 newProps.style.push({
                     color: cls
                 })

--- a/src/reactWrapper.js
+++ b/src/reactWrapper.js
@@ -7,11 +7,10 @@ import lineHeights from "./styles/lineHeight"
 
 /*
  * Wrap takes a Component or a render function and recursively replaces
- * the prop 'cls' (or custom overriden prop name) with the respective 'style' definitions.
- * Usually, wrapping a whole Class / Component will do the trick,
- * but for some render functions (e.g. ListView -> renderHeader)
- * this will not work. Hence the such functions need to be wrapped
- *individually
+ * the prop 'cls' (or custom overridden prop name) with the respective 'style' definitions.
+ * Render functions are decorated so that when they are invoked the resulting
+ * element tree will be be recursively evaluated and 'cls' will be replaced with
+ * 'style' definitions.
  */
 export function wrap(componentOrFunction) {
     if (!(componentOrFunction.prototype && "render" in componentOrFunction.prototype)) {
@@ -131,6 +130,15 @@ function recursiveStyle(elementsTree) {
 
         /* Convert single child */
         const converted = recursiveStyle(newChildren);
+        if (converted !== newChildren) {
+            translated = true;
+            newChildren = converted;
+        }
+    } else if (_.isFunction(newChildren)) {
+
+        /* Convert a fumction child to evaluate on invocation */
+        const originalChildrenFunction = newChildren;
+        const converted = (...args) => recursiveStyle(originalChildrenFunction(...args));
         if (converted !== newChildren) {
             translated = true;
             newChildren = converted;

--- a/src/reactWrapper.js
+++ b/src/reactWrapper.js
@@ -46,7 +46,7 @@ function setStyles(props, clsPropName) {
         newProps.style = []
     }
 
-    const splitted = props[clsPropName].replace(/-/g, "_").split(" ")
+    const splitted = props[clsPropName].replace(/-/gu, "_").split(" ")
     const fontSize = _.find(_.keys(typeScale), fSetting => _.includes(splitted, fSetting));
 
     for (let i = 0; i < splitted.length; i++) {
@@ -65,7 +65,7 @@ function setStyles(props, clsPropName) {
                 }
 
                 newProps.style.push({
-                    lineHeight: lineHeights[cls.replace(/_/g, "-")] * styles[fontSize].fontSize
+                    lineHeight: lineHeights[cls.replace(/_/gu, "-")] * styles[fontSize].fontSize
                 })
 
             } else if (cls.startsWith("bg_")) {

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -98,6 +98,8 @@ test("colors", t => {
 
 
 test("wrapping", t => {
+    const TestContext = React.createContext()
+    const tesContextValue = { test: 'testValue' };
 
     function createComponent(clsStr, style) {
         const comp = class extends React.Component {
@@ -133,7 +135,20 @@ test("wrapping", t => {
                         >
                             <div />
                         </div>
+                        <TestContext.Provider value={tesContextValue}>
+                            <TestContext.Consumer>
+                                {context => (
+                                    <div
+                                        key="child5"
+                                        cls="bg-white burlywood"
+                                >
+                                {context.test}
+                                    </div>
+                            )}
+                            </TestContext.Consumer>
+                        </TestContext.Provider>
                     </div>
+                    
                 )
             }
         }
@@ -159,7 +174,7 @@ test("wrapping", t => {
     t.deepEqual(result.props.other, "2", "other properties are preserved");
     t.deepEqual(result.props.children[0].props.cls, "w2", "child is preserved");
     t.deepEqual(result.props.children[0].props.style, [{ width: 32 }], "child cls is converted");
-    t.deepEqual(result.props.children.length, 4, "children are converted");
+    t.deepEqual(result.props.children.length, 5, "children are converted");
     t.deepEqual(result.props.children[0].props.children.props.style, [{ width: 128 }], "nested single children are converted");
     t.deepEqual(result.props.children[1].props.children, "Test", "Non-ReactElement children are preserved");
     t.ok(React.isValidElement(result.props.children[2].props.children), "unaltered single children are preserved");
@@ -172,6 +187,15 @@ test("wrapping", t => {
             { color: "burlywood" }
         ],
         "ad-hoc colors are supported"
+    );
+
+    t.deepEqual(
+        result.props.children[4].props.children.props.children(tesContextValue).props.style,
+        [
+            { backgroundColor: 'white' },
+            { color: 'burlywood' }
+        ],
+        "render props are supported"
     );
 
     t.deepEqual(result.props.style, [{ width: 256 }], "style array is created");


### PR DESCRIPTION
When using the React Context API, and other render functions, I noticed that the tachyon styles weren't applied to the function result. In the example below the `Text` element would not have the correct styles applied. The workaround solution would be to use a separate wrapped component as the return value of the render function.

I updated `recursiveStyle` to decorate function child elements with `recursiveStyle`. The resultant function, when invoked, will apply tachyon styles as expected.

```
NativeTachyons.wrap(class Example extends React.Component {
  render() {
    return (
      <Context.Consumer>
        {context => (
          <Text cls="bg-white">{context}</Text>
        )}
      </Context.Consumer>
    );
  }
})
```