### PR TITLE
Prevent applying styles unnecessarily

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const hyphensToUnderscores = function(sourceObj) {
 
     /* Create hypened versions */
     _.forOwn(sourceObj, (val, key) => {
-        translated[key.replace(/-/g, "_")] = val;
+        translated[key.replace(/-/gu, "_")] = val;
     })
 
     return translated;

--- a/src/reactWrapper.js
+++ b/src/reactWrapper.js
@@ -50,7 +50,7 @@ function setStyles(props, clsPropName) {
         newProps.style = []
     }
 
-    const splitted = props[clsPropName].replace(/-/g, "_").split(" ")
+    const splitted = props[clsPropName].replace(/-/gu, "_").split(" ")
     const fontSize = _.find(_.keys(typeScale), fSetting => _.includes(splitted, fSetting));
 
     for (let i = 0; i < splitted.length; i++) {
@@ -69,7 +69,7 @@ function setStyles(props, clsPropName) {
                 }
 
                 newProps.style.push({
-                    lineHeight: lineHeights[cls.replace(/_/g, "-")] * styles[fontSize].fontSize
+                    lineHeight: lineHeights[cls.replace(/_/gu, "-")] * styles[fontSize].fontSize
                 })
 
             } else if (cls.startsWith("bg_")) {
@@ -87,7 +87,7 @@ function setStyles(props, clsPropName) {
                     tintColor: cls.slice(3)
                 })
 
-            } else if (cssColors[cls] || (/^(rgb|#|hsl)/).test(cls)) {
+            } else if (cssColors[cls] || (/^(rgb|#|hsl)/u).test(cls)) {
                 newProps.style.push({
                     color: cls
                 })

--- a/src/reactWrapper.js
+++ b/src/reactWrapper.js
@@ -30,7 +30,7 @@ export function wrap(componentOrFunction) {
     }
 
     /* Fix name */
-    newClass.displayName = WrappedComponent.displayName || WrappedComponent.name;
+    newClass.displayName = WrappedComponent.displayName || WrappedComponent.name
 
     /* Mark the class as wrapped by tachyons */
     newClass.isTachyonsWrapped = true;

--- a/src/reactWrapper.js
+++ b/src/reactWrapper.js
@@ -30,7 +30,10 @@ export function wrap(componentOrFunction) {
     }
 
     /* Fix name */
-    newClass.displayName = WrappedComponent.displayName || WrappedComponent.name
+    newClass.displayName = WrappedComponent.displayName || WrappedComponent.name;
+
+    /* Mark the class as wrapped by tachyons */
+    newClass.isTachyonsWrapped = true;
 
     return newClass;
 }
@@ -100,6 +103,16 @@ function setStyles(props, clsPropName) {
 }
 
 function recursiveStyle(elementsTree) {
+
+    /*
+     * If the node type is wrapped by tachyons then return immediately. This
+     * will prevent unnecessarily applying styles to elements that have already
+     * been wrapped.
+     */
+    if (elementsTree.type.isTachyonsWrapped) {
+        return elementsTree;
+    }
+
     const { props } = elementsTree;
     const { clsPropName } = options;
     let newProps = null;


### PR DESCRIPTION
I noticed that the `recursiveStyles` method would apply styles to nodes that were already wrapped by Tachyons. The result was that nodes would have styles applied multiple times. In the below example, `ComponentA` and `ComponentB` are both wrapped by tachyons. When `ComponentA` renders the `white` color is applied to the text. Later, when `ComponentB` is rendered, the background color is applied the View AND the `white` color is reapplied to the `Text` element.

```jsx
const ComponentA = NativeTachyons.wrap(({ text }) => <Text cls="white">{text}</Text>);

const ComponentB = NativeTachyons.wrap(({ text, backgroundColor }) => (
    <View cls={`bg-${backgroundColor}`}>
      <ComponentA text={textA} />
    </View>
  )
)
```

The solution I used was to apply a property to the wrapped class indicating that it was wrapped by Tachyons. The `recursiveStyles` function uses this to prevent evaluating element trees that are already wrapped by Tachyons.

