### PR TITLE
import styles/lineHeight into src/index along with other styles #83 - WIP

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import typeScale from "./styles/typeScale"
 import text from "./styles/text"
 import images from "./styles/images"
 import fontWeights from "./styles/fontWeights"
+import { lineHeightsWithProperties as lineHeights } from "./styles/lineHeight"
 import opacity from "./styles/opacity"
 import * as absolute from "./styles/absolute"
 import tracked from "./styles/tracked"
@@ -20,7 +21,7 @@ const hyphensToUnderscores = function(sourceObj) {
 
     /* Create hypened versions */
     _.forOwn(sourceObj, (val, key) => {
-        translated[key.replace(/-/g, "_")] = val;
+        translated[key.replace(/-/gu, "_")] = val;
     })
 
     return translated;
@@ -56,6 +57,7 @@ const NativeTachyons = {
         _.assign(styleSheet, borders.styles)
         _.assign(styleSheet, flexbox)
         _.assign(styleSheet, fontWeights)
+        _.assign(styleSheet, lineHeights)
         _.assign(styleSheet, images)
         _.assign(styleSheet, text)
         _.assign(styleSheet, opacity)
@@ -72,7 +74,8 @@ const NativeTachyons = {
             spacing,
             typeScale,
             borders.radii,
-            tracked
+            tracked,
+            lineHeights
         ]
 
         REM_SCALED.forEach(subSheet => {

--- a/src/reactWrapper.js
+++ b/src/reactWrapper.js
@@ -47,7 +47,7 @@ function setStyles(props, clsPropName) {
         newProps.style = []
     }
 
-    const splitted = props[clsPropName].replace(/-/g, "_").split(" ")
+    const splitted = props[clsPropName].replace(/-/gu, "_").split(" ")
     const fontSize = _.find(_.keys(typeScale), fSetting => _.includes(splitted, fSetting));
 
     for (let i = 0; i < splitted.length; i++) {
@@ -66,7 +66,7 @@ function setStyles(props, clsPropName) {
                 }
 
                 newProps.style.push({
-                    lineHeight: lineHeights[cls.replace(/_/g, "-")] * styles[fontSize].fontSize
+                    lineHeight: lineHeights[cls.replace(/_/gu, "-")] * styles[fontSize].fontSize
                 })
 
             } else if (cls.startsWith("bg_")) {
@@ -84,7 +84,8 @@ function setStyles(props, clsPropName) {
                     tintColor: cls.slice(3)
                 })
 
-            } else if (cssColors[cls] || (/^(rgb|#|hsl)/).test(cls)) {
+
+            } else if (cssColors[cls] || (/^(rgb|#|hsl)/u).test(cls)) {
                 newProps.style.push({
                     color: cls
                 })

--- a/src/styles/lineHeight.js
+++ b/src/styles/lineHeight.js
@@ -1,5 +1,12 @@
-export default {
-    "lh-solid": 1,
-    "lh-title": 1.25,
-    "lh-copy": 1.5
+import _ from "lodash"
+
+const lineHeights = {
+  "lh-solid": 1,
+  "lh-title": 1.25,
+  "lh-copy": 1.5
 }
+
+
+export const lineHeightsWithProperties = _.mapValues(lineHeights, val => ({ lineHeight: val }))
+
+export default lineHeights


### PR DESCRIPTION
`Issue:`: When importing `NativeTachyons.Styles` `StyleSheet` I found I could not locate any of the lineHeight types `lh-type` in the `NativeTachyons.Styles` sheet. The `lineHeights` are currently only being imported and utilized for the ReactWrapper.

* Here we maintain the same API for the lineHeight style by exporting the same default, in the same shape, instead
* we export a modified version with each `lineHeight` property mapped to a style property `lineHeight: value`
* we then import this modified version/variant into `src/index.js` and treat it the same as any other style being imported from the `styles` directory